### PR TITLE
add `null` and `{}` operands

### DIFF
--- a/format_decision_rules/format_decision_rules.json
+++ b/format_decision_rules/format_decision_rules.json
@@ -208,6 +208,58 @@
     }
   },
   {
+    "title": "is_missing_enum",
+    "rules": [
+      {
+        "operator": "is",
+        "operand": null,
+        "type": "enum"
+      }
+    ],
+    "expectation": {
+      "string": "is null"
+    }
+  },
+  {
+    "title": "is_missing_continuous",
+    "rules": [
+      {
+        "operator": "is",
+        "operand": null,
+        "type": "continuous"
+      }
+    ],
+    "expectation": {
+      "string": "is null"
+    }
+  },
+  {
+    "title": "is_optional_enum",
+    "rules": [
+      {
+        "operator": "is",
+        "operand": {},
+        "type": "enum"
+      }
+    ],
+    "expectation": {
+      "string": "is N/A"
+    }
+  },
+  {
+    "title": "is_optional_continuous",
+    "rules": [
+      {
+        "operator": "is",
+        "operand": {},
+        "type": "continous"
+      }
+    ],
+    "expectation": {
+      "string": "is N/A"
+    }
+  },
+  {
     "title": "multiple_rules",
     "rules": [
       {


### PR DESCRIPTION
I added `is null`and `is N/A` in the decision rules formatting tests